### PR TITLE
First commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2.1
+jobs:
+  test:
+    docker:
+      - image: alpine
+    steps:
+      - run: "true"
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+*.class
+*.log
+logs/
+
+# sbt specific
+.cache
+.history
+.lib/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+native/
+
+# Scala-IDE specific
+.scala_dependencies
+.worksheet
+*.sc
+.idea/*
+
+# Ipython
+*.ipynb*
+
+# leveldb
+journal/
+
+# Mac
+.DS_Store
+
+# Ensime
+.ensime
+.ensime_cache/
+
+# Emacs temp files
+.#*
+\#*#
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+sudo: false
+
+language: scala
+
+jdk: oraclejdk8
+
+scala: 2.12.8
+
+services:
+  - docker
+
+before_cache:
+  # Cleanup the cached directories to avoid unnecessary cache updates
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - rm -f $HOME/.cache/pip/log/debug.log
+
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.cache/pip
+    - $HOME/.sbt/boot
+    - $HOME/.coursier/cache
+
+jobs:
+  include:
+    - script:
+      - docker-compose up -d
+      - timeout 20 ./docker-compose-healthycheck.sh kafka010
+      - timeout 20 ./docker-compose-healthycheck.sh kafka210
+      - sbt test
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:8-alpine
+RUN apk add bash
+COPY ./target/scala-2.12/kafka-topic-mirror.jar /tmp
+COPY ./entrypoint.sh /tmp
+WORKDIR /tmp
+ENTRYPOINT ["./entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:8-alpine
-RUN apk add bash
+RUN apk add --no-cache bash=*
 RUN mkdir /app
 COPY ./target/scala-2.12/kafka-topic-mirror.jar /app
 COPY ./entrypoint.sh /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM openjdk:8-alpine
 RUN apk add bash
-COPY ./target/scala-2.12/kafka-topic-mirror.jar /tmp
-COPY ./entrypoint.sh /tmp
-WORKDIR /tmp
+RUN mkdir /app
+COPY ./target/scala-2.12/kafka-topic-mirror.jar /app
+COPY ./entrypoint.sh /app
+WORKDIR /app
 ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -15,12 +15,16 @@ A console app that diff and mirror topics metadata from a kafka to another
 ```bash
 $ sbt assembly 
 $ java -jar target/scala-2.12/kafka-topic-mirror.jar 
-Diff or mirror topics between kafkas.
+Diff or mirror topics metadata between kafkas.
 Option                                   Description                           
 ------                                   -----------                           
 --bootstrap-servers-dst <String: hosts>  REQUIRED: The connection string for   
                                            the kafka connection in the form    
-                                           host:port.                          
+                                           host:port.
+--command-config-property-dst <String:   A mechanism to pass user-defined       
+  dst_prop>                                properties in the form key=value to  
+                                           the destination kafka Admin Client   
+                                           connection. Multiple entries allowed.                                                              
 --diff                                   List topics differences.              
 --help                                   Print usage information.              
 --mirror                                 Change or create topics on destination

--- a/build.sbt
+++ b/build.sbt
@@ -9,11 +9,9 @@ scalaVersion := "2.12.8"
 libraryDependencies += "org.apache.kafka" %% "kafka" % "2.2.0"
 libraryDependencies += "org.scala-sbt" %% "command" % "1.2.8"
 libraryDependencies += "net.sf.jopt-simple" % "jopt-simple" % "5.0.4"
-libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.26"
-
+libraryDependencies += "org.slf4j" % "slf4j-log4j12" % "1.7.26"
 
 libraryDependencies += "org.scalatest" % "scalatest_2.12" % "3.0.5" % "test"
-libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.26" % "test"
 
 parallelExecution in Test := false
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,24 @@
+name := "kafka-topic-mirror.scala"
+
+organization := "co.cobli"
+
+version := "0.1"
+
+scalaVersion := "2.12.8"
+
+libraryDependencies += "org.apache.kafka" %% "kafka" % "2.2.0"
+libraryDependencies += "org.scala-sbt" %% "command" % "1.2.8"
+libraryDependencies += "net.sf.jopt-simple" % "jopt-simple" % "5.0.4"
+libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.26"
+
+
+libraryDependencies += "org.scalatest" % "scalatest_2.12" % "3.0.5" % "test"
+libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.26" % "test"
+
+parallelExecution in Test := false
+
+mainClass in (Compile, run) := Some("co.cobli.kafka.mirror.TopicsMirrorCommand")
+
+mainClass in assembly := Some("co.cobli.kafka.mirror.TopicsMirrorCommand")
+test in assembly := {}
+assemblyJarName in assembly := s"kafka-topic-mirror.jar"

--- a/docker-compose-healthycheck.sh
+++ b/docker-compose-healthycheck.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+ctnr_name=$(docker-compose ps -q $1)
+
+while true; do
+    status=$(docker inspect -f '{{.State.Health.Status}}' "$ctnr_name")
+    [[ "$status" != "healthy" ]] || break
+    sleep 1
+done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,86 @@
+version: '3.4'
+
+x-zoo-healthcheck: &zoo-healthcheck
+  test: ["CMD", "echo", "srvr", "|", "nc", "-w", "1", "127.0.0.1","2181","|", "grep", "-qi", "zookeeper"]
+  interval: 5s
+  timeout: 1s
+  retries: 5
+
+x-kafka-healthcheck: &kafka-healthcheck
+  test: ["CMD", "kafka-topics", "--list", "--zookeeper", "xxx"]
+  interval: 5s
+  timeout: 10s
+  retries: 6
+
+
+services:
+
+  zoo010:
+    image: zookeeper
+    restart: always
+    ports:
+      - 2181:2181
+    environment:
+      ZOO_MY_ID: 1
+      ZOO_SERVERS: server.1=0.0.0.0:2888:3888
+      ZOO_INIT_LIMIT: 30
+      ZOO_SYNC_LIMIT: 30
+    healthcheck:
+      <<: *zoo-healthcheck
+
+  kafka010:
+    image: confluentinc/cp-kafka:3.2.2
+    restart: always
+    depends_on:
+      - zoo010
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka010:9092
+      KAFKA_ZOOKEEPER_CONNECT: zoo010:2181
+      KAFKA_DELETE_TOPIC_ENABLE: "true"
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+    healthcheck:
+      <<: *kafka-healthcheck
+      test: ["CMD", "kafka-topics", "--list", "--zookeeper", "zoo010:2181"]
+
+
+  zoo210:
+    image: confluentinc/cp-kafka:5.1.2
+    restart: always
+    volumes:
+      - "./kafka-playground/zk_server_jaas.conf:/conf/zk_server_jaas.conf"
+    command:
+      - /usr/bin/zookeeper-server-start
+      - /etc/kafka/zookeeper.properties
+    environment:
+      ZOO_MY_ID: 1
+      ZOO_SERVERS: server.1=0.0.0.0:2888:3888
+      KAFKA_OPTS: -Djava.security.auth.login.config=/conf/zk_server_jaas.conf
+    healthcheck:
+      <<: *zoo-healthcheck
+
+  kafka210:
+    image: confluentinc/cp-kafka:5.1.2
+    restart: always
+    volumes:
+      - "./kafka-playground/kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf"
+    depends_on:
+      - zoo210
+    ports:
+      - 9092:9092
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zoo210:2181
+      KAFKA_DELETE_TOPIC_ENABLE: "true"
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      KAFKA_SECURITY_INTER_BROKER_PROTOCOL: SASL_PLAINTEXT
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      KAFKA_ADVERTISED_LISTENERS: SASL_PLAINTEXT://localhost:9092
+      KAFKA_OPTS: -Djava.security.auth.login.config=/etc/kafka/kafka_server_jaas.conf
+    healthcheck:
+      <<: *kafka-healthcheck
+      test: ["CMD", "kafka-topics", "--list", "--zookeeper", "zoo210:2181"]
+
+
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,4 +14,4 @@ while IFS="=" read key value; do
 done < <(env)
 
 
-java -jar kafka-topic-mirror.jar "${@}" "${DST_PROPS[@]}"
+java -jar $JAVA_OPTS $TOPIC_MIRROR_JAVA_OPTS $TOPIC_MIRROR_LOG4J_OPTS /app/kafka-topic-mirror.jar "${@}" "${DST_PROPS[@]}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+DST_PROPS=()
+
+while IFS="=" read key value; do
+	if [[ "$key" != COMMAND_CONFIG_PROPERTY_DST_* ]]; then
+		continue
+	fi
+	key=${key#"COMMAND_CONFIG_PROPERTY_DST_"}
+	key="${key,,}" # strtolower
+	key=${key//_/.}
+	entry="${key}=${value}"
+	DST_PROPS+=("--command-config-property-dst" "${entry}")
+done < <(env)
+
+
+java -jar kafka-topic-mirror.jar "${@}" "${DST_PROPS[@]}"

--- a/kafka-playground/kafka010.yml
+++ b/kafka-playground/kafka010.yml
@@ -1,0 +1,71 @@
+version: '3.4'
+
+
+x-kafka-common: &kafka-common
+  image: confluentinc/cp-kafka:3.2.2
+  restart: always
+  depends_on:
+    - zoo010-1
+    - zoo010-2
+    - zoo010-3
+
+x-kafka-env-common: &kafka-common-env
+  KAFKA_ZOOKEEPER_CONNECT: zoo010-1:2181,zoo010-2:2181,zoo010-3:2181
+  KAFKA_DELETE_TOPIC_ENABLE: "true"
+  KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+
+x-zoo-common: &zoo-common
+  image: zookeeper
+  restart: always
+
+x-zoo-env-common: &zoo-common-env
+  ZOO_INIT_LIMIT: 30
+  ZOO_SYNC_LIMIT: 30
+
+services:
+
+
+  zoo010-1:
+    <<: *zoo-common
+    ports:
+      - 2181:2181
+    environment:
+      <<: *zoo-common-env
+      ZOO_MY_ID: 1
+      ZOO_SERVERS: server.1=0.0.0.0:2888:3888 server.2=zoo010-2:2888:3888 server.3=zoo010-3:2888:3888
+
+  zoo010-2:
+    <<: *zoo-common
+    environment:
+      <<: *zoo-common-env
+      ZOO_MY_ID: 2
+      ZOO_SERVERS: server.1=zoo010-1:2888:3888 server.2=0.0.0.0:2888:3888 server.3=zoo010-3:2888:3888
+
+  zoo010-3:
+    <<: *zoo-common
+    environment:
+      <<: *zoo-common-env
+      ZOO_MY_ID: 3
+      ZOO_SERVERS: server.1=zoo010-1:2888:3888 server.2=zoo010-2:2888:3888 server.3=0.0.0.0:2888:3888
+
+  kafka010-1:
+    <<: *kafka-common
+    environment:
+      <<: *kafka-common-env
+      KAFKA_BROKER_ID: 1
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka010-1:9092
+
+
+  kafka010-2:
+    <<: *kafka-common
+    environment:
+      <<: *kafka-common-env
+      KAFKA_BROKER_ID: 2
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka010-2:9092
+
+  kafka010-3:
+    <<: *kafka-common
+    environment:
+      <<: *kafka-common-env
+      KAFKA_BROKER_ID: 3
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka010-3:9092

--- a/kafka-playground/kafka210.yml
+++ b/kafka-playground/kafka210.yml
@@ -1,0 +1,72 @@
+version: '3.4'
+
+
+x-zoo-common: &zoo-common
+  image: zookeeper
+  restart: always
+
+x-zoo-env-common: &zoo-common-env
+  ZOO_INIT_LIMIT: 30
+  ZOO_SYNC_LIMIT: 30
+
+
+x-kafka-common: &kafka-common
+  image: confluentinc/cp-kafka:5.1.2
+  restart: always
+  depends_on:
+    - zoo210-1
+    - zoo210-2
+    - zoo210-3
+
+x-kafka-env-common: &kafka-common-env
+  KAFKA_ZOOKEEPER_CONNECT: zoo210-1:2181,zoo210-2:2181,zoo210-3:2181
+  KAFKA_DELETE_TOPIC_ENABLE: "true"
+  KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+
+
+services:
+
+  zoo210-1:
+    <<: *zoo-common
+    ports:
+      - 12181:2181
+    environment:
+      <<: *zoo-common-env
+      ZOO_MY_ID: 1
+      ZOO_SERVERS: server.1=0.0.0.0:2888:3888 server.2=zoo210-2:2888:3888 server.3=zoo210-3:2888:3888
+
+  zoo210-2:
+    <<: *zoo-common
+    environment:
+      <<: *zoo-common-env
+      ZOO_MY_ID: 2
+      ZOO_SERVERS: server.1=zoo210-1:2888:3888 server.2=0.0.0.0:2888:3888 server.3=zoo210-3:2888:3888
+
+  zoo210-3:
+    <<: *zoo-common
+    environment:
+      <<: *zoo-common-env
+      ZOO_MY_ID: 3
+      ZOO_SERVERS: server.1=zoo210-1:2888:3888 server.2=zoo210-2:2888:3888 server.3=0.0.0.0:2888:3888
+
+  kafka210-1:
+    <<: *kafka-common
+    environment:
+      <<: *kafka-common-env
+      KAFKA_BROKER_ID: 1
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka210-1:9092
+
+
+  kafka210-2:
+    <<: *kafka-common
+    environment:
+      <<: *kafka-common-env
+      KAFKA_BROKER_ID: 2
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka210-2:9092
+
+  kafka210-3:
+    <<: *kafka-common
+    environment:
+      <<: *kafka-common-env
+      KAFKA_BROKER_ID: 3
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka210-3:9092

--- a/kafka-playground/kafka_server_jaas.conf
+++ b/kafka-playground/kafka_server_jaas.conf
@@ -1,0 +1,12 @@
+KafkaServer {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+  username="admin"
+  password="admin-secret"
+  user_admin="admin-secret";
+};
+
+Client {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+  username="admin"
+  password="admin-secret";
+};

--- a/kafka-playground/zk_server_jaas.conf
+++ b/kafka-playground/zk_server_jaas.conf
@@ -1,0 +1,6 @@
+Server {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+  username="admin"
+  password="admin-secret"
+  user_admin="admin-secret";
+};

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 1.2.8

--- a/src/main/scala/META-INF/MANIFEST.MF
+++ b/src/main/scala/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: co.cobli.kafka.mirroring.TopicsMirrorCommand
+

--- a/src/main/scala/co/cobli/kafka/mirror/KafkaClientImplicits.scala
+++ b/src/main/scala/co/cobli/kafka/mirror/KafkaClientImplicits.scala
@@ -1,0 +1,103 @@
+
+package co.cobli.kafka.mirror
+
+import java.util
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+import kafka.server.ConfigType
+import kafka.zk.{AdminZkClient, KafkaZkClient}
+import org.apache.kafka.clients.admin.{AdminClient, Config, ConfigEntry, NewTopic}
+import org.apache.kafka.common.config.ConfigResource
+import org.apache.kafka.common.internals.Topic
+
+
+/**
+  * Complements KafkaClient's (KafkaZkClient and AdminClient) with standardized methods for topic management
+  *
+  */
+object KafkaClientImplicits {
+
+  implicit class TopicsReadableZkAdapter(client: KafkaZkClient) extends TopicsReading {
+
+    def getNonInternalTopics: Set[String] = {
+      val allTopics = client.getAllTopicsInCluster.toSet
+      allTopics.filterNot(Topic.isInternal)
+    }
+
+    def getTopicsInfo(topics: Set[String] = getNonInternalTopics): Map[String, TopicInfo] = {
+      val adminZkClient = new AdminZkClient(client)
+
+      val topicsInfo: mutable.Map[String, TopicInfo] = mutable.Map.empty
+
+      val assignments = client.getPartitionAssignmentForTopics(topics)
+
+      for (topic <- topics) {
+        if (!client.isTopicMarkedForDeletion(topic)) {
+          val topicPartitionAssignment = assignments(topic)
+          val replicationFactor = topicPartitionAssignment.head._2.size
+          val numPartitions = topicPartitionAssignment.size
+          val configs = adminZkClient.fetchEntityConfig(ConfigType.Topic, topic).asScala
+          topicsInfo += (topic -> TopicInfo(
+            numPartitions = numPartitions,
+            replicationFactor = replicationFactor,
+            config = configs.toMap
+          ))
+        }
+      }
+      topicsInfo.toMap
+    }
+  }
+
+  implicit class TopicsManageableKafkaAdapter(client: AdminClient) extends TopicsManaging {
+
+    def getNonInternalTopics: Set[String] = {
+      val allTopics = client.listTopics()
+      allTopics.names().get().asScala.toSet
+    }
+
+    def getTopicsInfo(topics: Set[String] = getNonInternalTopics): Map[String, TopicInfo] = {
+      val topicsParam = topics.map(topicConfigResource).asJavaCollection
+
+      val topicsConfigs = client.describeConfigs(topicsParam).all.get
+
+      val topicsDescriptions = client.describeTopics(topics.asJavaCollection).all.get.asScala
+
+      topicsDescriptions.mapValues(
+        topicDescription => {
+          val configIndex = topicConfigResource(topicDescription.name)
+          val config = topicsConfigs.get(configIndex).entries.asScala.map(
+            entry => entry.name -> entry.value
+          )
+          TopicInfo(
+            numPartitions = topicDescription.partitions.size,
+            replicationFactor = topicDescription.partitions.iterator.next.replicas.size,
+            config = config.toMap
+          )
+        }
+      ).toMap
+    }
+
+    def createTopic(newTopic: NewTopic): Unit = {
+      client.createTopics(Set(newTopic).asJava).all.get
+    }
+
+    def alterTopicConfig(name: String, config: Map[String, String]): Unit = {
+      val newConfig = new Config(
+        config.map { case (key, value) => new ConfigEntry(key, value) }.asJavaCollection
+      )
+
+      val alterParam = new util.HashMap[ConfigResource, Config] {
+        put(topicConfigResource(name), newConfig)
+      }
+
+      client.alterConfigs(alterParam).all.get
+    }
+
+    private def topicConfigResource(name: String): ConfigResource ={
+      new ConfigResource(ConfigResource.Type.TOPIC, name)
+    }
+  }
+
+}

--- a/src/main/scala/co/cobli/kafka/mirror/TopicInfo.scala
+++ b/src/main/scala/co/cobli/kafka/mirror/TopicInfo.scala
@@ -1,0 +1,15 @@
+
+package co.cobli.kafka.mirror
+
+import scala.collection.JavaConverters._
+
+import org.apache.kafka.clients.admin.Config
+
+
+case class TopicInfo(numPartitions: Int, replicationFactor: Int, config: Map[String, String])
+
+object TopicInfo {
+  def apply(numPartitions: Int, replicationFactor: Int, config: Option[Config]): TopicInfo = {
+    new TopicInfo(numPartitions: Int, replicationFactor, config.get.entries().asScala.map(entry => entry.name() -> entry.value()).toMap)
+  }
+}

--- a/src/main/scala/co/cobli/kafka/mirror/TopicMirroring.scala
+++ b/src/main/scala/co/cobli/kafka/mirror/TopicMirroring.scala
@@ -1,0 +1,30 @@
+
+package co.cobli.kafka.mirror
+
+
+trait TopicMirroring extends TopicsComparing {
+
+  /**
+    * Mirror a specific topic based on a TopicDiff
+    * @param name
+    * @param diff
+    * @param dst
+    */
+  def mirrorTopic(name: String, diff: TopicDiff, dst: TopicsManaging): Unit = {
+    diff.diffType match {
+      case TopicDiffType.MISSING =>
+        println(s"creating topic $name")
+        dst.createTopic(diff.asNewTopic(name))
+      case TopicDiffType.DIFFER =>
+        diff.config match {
+          case Some(conf) =>
+            println(s"updating topic $name config with $conf")
+            dst.alterTopicConfig(name, conf)
+          case None => ()
+        }
+        if (diff.needsManuallyIntervention()) System.err.println(s"$name needs manually intervention for $diff")
+      case TopicDiffType.EQUALS =>
+        println(s"nothing to be done for $name")
+    }
+  }
+}

--- a/src/main/scala/co/cobli/kafka/mirror/TopicsComparing.scala
+++ b/src/main/scala/co/cobli/kafka/mirror/TopicsComparing.scala
@@ -1,0 +1,82 @@
+
+package co.cobli.kafka.mirror
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+import org.apache.kafka.clients.admin.NewTopic
+
+
+trait TopicsComparing {
+
+  /**
+    * Compare a list of topics with its associated TopicInfo
+    * @param topicsInfoSrc source topics
+    * @param topicsInfoDst destination topics
+    * @return a map of TopicDiffs
+    */
+  def compareTopics(topicsInfoSrc: Map[String, TopicInfo], topicsInfoDst: Map[String, TopicInfo]): Map[String, TopicDiff] = {
+
+    val diff: mutable.Map[String, TopicDiff] = mutable.Map.empty
+
+    for ((topic, info) <- topicsInfoSrc) {
+      if (topicsInfoDst.contains(topic)) {
+        val infoDst = topicsInfoDst(topic)
+        val diffPartitions = info.numPartitions - infoDst.numPartitions
+        val diffReplicationFactor = info.replicationFactor - infoDst.replicationFactor
+        val config = if (info.config.equals(infoDst)) {
+          None
+        } else {
+          Some(info.config)
+        }
+        if (diffPartitions == 0 && diffReplicationFactor == 0 && config.isEmpty)
+          diff += topic -> TopicDiff(TopicDiffType.EQUALS, 0, 0, None)
+        else
+          diff += topic -> TopicDiff(TopicDiffType.DIFFER, diffPartitions, diffReplicationFactor, config)
+      } else {
+        diff += topic -> TopicDiff(TopicDiffType.MISSING, info.numPartitions, info.replicationFactor, Some(info.config))
+      }
+    }
+    diff.toMap
+  }
+
+  case class TopicDiff(diffType: TopicDiffType.Value, diffPartition: Int = 0, diffReplicationFactor: Int = 0, config: Option[Map[String, String]]) {
+
+    import TopicDiffType._
+
+
+    def asNewTopic(name: String): NewTopic = {
+      val newTopic = new NewTopic(name, diffPartition, diffReplicationFactor.toShort)
+      config match {
+        case Some(conf) => newTopic.configs(conf.asJava)
+        case _ => newTopic
+      }
+    }
+
+    def needsManuallyIntervention(): Boolean = diffPartition != 0 || diffReplicationFactor != 0
+
+    override def toString: String = {
+      {
+        if (diffType == MISSING) {
+          "needs create with "
+        } else if (diffType == DIFFER) {
+          "needs update with "
+        } else if (diffType == EQUALS) {
+          "is equals "
+        }
+      } +
+        f"partitions: $diffPartition%+d replication factor: $diffReplicationFactor%+d" + {
+        config match {
+          case None => ""
+          case Some(conf) => s" config: $conf"
+        }
+      }
+    }
+  }
+
+  object TopicDiffType extends Enumeration {
+    type DiffType = Value
+    val MISSING, DIFFER, EQUALS = Value
+  }
+
+}

--- a/src/main/scala/co/cobli/kafka/mirror/TopicsMirrorCommand.scala
+++ b/src/main/scala/co/cobli/kafka/mirror/TopicsMirrorCommand.scala
@@ -1,0 +1,102 @@
+
+package co.cobli.kafka.mirror
+
+import java.util.Properties
+
+import scala.collection.JavaConverters._
+import scala.collection._
+
+import joptsimple.{ArgumentAcceptingOptionSpec, OptionParser, OptionSet, OptionSpec, OptionSpecBuilder}
+import kafka.utils.{CommandLineUtils, Exit, Logging}
+import kafka.zk.KafkaZkClient
+import org.apache.kafka.clients.admin._
+import org.apache.kafka.common.utils.{Time, Utils}
+
+import co.cobli.kafka.mirror.KafkaClientImplicits._
+
+
+object TopicsMirrorCommand extends Logging with TopicMirroring {
+
+  def main(args: Array[String]): Unit = {
+
+    val opts = new TopicsMetadataUpsertCommandOptions(args)
+
+    if (args.length == 0)
+      CommandLineUtils.printUsageAndDie(opts.parser, "Diff or mirror topics between Kafkas.")
+
+    // should have exactly one action
+    val actions = Seq(opts.diffOpt, opts.mirrorOpt, opts.helpOpt).count(opts.options.has)
+    if (actions != 1)
+      CommandLineUtils.printUsageAndDie(opts.parser, "Command must include exactly one action: --diff or --mirror")
+
+    opts.checkArgs()
+
+    val zkClientSrc = KafkaZkClient(
+      connectString = opts.options.valueOf(opts.zkConnectOptSrc),
+      isSecure = false,
+      sessionTimeoutMs = 10000,
+      connectionTimeoutMs = 10000,
+      maxInFlightRequests = 10000,
+      time = Time.SYSTEM
+    )
+
+    opts.configPropsDst.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, opts.options.valueOf(opts.kafkaConnectOptDst))
+
+    val kafkaClientDst = AdminClient.create(opts.configPropsDst)
+    var exitCode = 0
+    val diffs = compareTopics(zkClientSrc.getTopicsInfo(), kafkaClientDst.getTopicsInfo())
+    try {
+      for ((topic, diff) <- diffs) {
+        if (opts.options.has(opts.mirrorOpt)) {
+          mirrorTopic(topic, diff, kafkaClientDst)
+        }
+      }
+    } catch {
+      case e: Throwable =>
+        println("Error while executing topic command : " + e.getMessage)
+        error(Utils.stackTrace(e))
+        exitCode = 1
+    } finally {
+      zkClientSrc.close()
+      kafkaClientDst.close()
+      Exit.exit(exitCode)
+    }
+  }
+
+  class TopicsMetadataUpsertCommandOptions(args: Array[String]) {
+    val parser = new OptionParser(false)
+    val zkConnectOptSrc: ArgumentAcceptingOptionSpec[String] = parser.accepts("zookeeper-src", "REQUIRED: The connection string for the source zookeeper connection in the form host:port. " +
+      "Multiple hosts can be given to allow fail-over.")
+      .withRequiredArg
+      .describedAs("hosts")
+      .ofType(classOf[String])
+    val kafkaConnectOptDst: ArgumentAcceptingOptionSpec[String] = parser.accepts("bootstrap-servers-dst", "REQUIRED: The connection string for the destination kafka connection in the form " +
+      "host:port.")
+      .withRequiredArg
+      .describedAs("hosts")
+      .ofType(classOf[String])
+
+    val commandConfigPropertyOptDst: ArgumentAcceptingOptionSpec[String] = parser.accepts("command-config-property-dst", "A mechanism to pass user-defined properties in the form " +
+      "key=value to the destination kafka Admin Client connection. Multiple entries allowed.")
+      .withRequiredArg
+      .describedAs("dst_prop")
+      .ofType(classOf[String])
+
+    val diffOpt: OptionSpecBuilder = parser.accepts("diff", "List topics differences.")
+    val mirrorOpt: OptionSpecBuilder = parser.accepts("mirror", "Change or create topics on destination")
+    val helpOpt: OptionSpecBuilder = parser.accepts("help", "Print usage information.")
+
+    val options: OptionSet = parser.parse(args: _*)
+
+    val configPropsDst: Properties = CommandLineUtils.parseKeyValueArgs(options.valuesOf(commandConfigPropertyOptDst).asScala)
+
+    val allTopicLevelOpts: Set[OptionSpec[_]] = Set(diffOpt, mirrorOpt, helpOpt)
+
+    def checkArgs() {
+      // check required args
+      CommandLineUtils.checkRequiredArgs(parser, options, zkConnectOptSrc)
+      CommandLineUtils.checkRequiredArgs(parser, options, kafkaConnectOptDst)
+    }
+  }
+
+}

--- a/src/main/scala/co/cobli/kafka/mirror/package.scala
+++ b/src/main/scala/co/cobli/kafka/mirror/package.scala
@@ -1,0 +1,19 @@
+
+package co.cobli.kafka.mirror
+
+import org.apache.kafka.clients.admin.NewTopic
+
+
+trait TopicsReading {
+  def getNonInternalTopics: Set[String]
+
+  def getTopicsInfo(topics: Set[String] = getNonInternalTopics): Map[String, TopicInfo]
+}
+
+trait TopicsWriting {
+  def createTopic(newTopic: NewTopic)
+
+  def alterTopicConfig(topic: String, config: Map[String, String])
+}
+
+trait TopicsManaging extends TopicsReading with TopicsWriting

--- a/src/test/scala/co/cobli/kafka/mirror/SystemExitInterceptor.scala
+++ b/src/test/scala/co/cobli/kafka/mirror/SystemExitInterceptor.scala
@@ -9,7 +9,7 @@ import java.security.Permission
   */
 trait SystemExitInterceptor {
 
-  sealed case class ExitException(status: Int) extends SecurityException("System.exit() is not allowed")
+  sealed case class ExitException(status: Int) extends Throwable(s"System.exit() is called with status $status")
 
   def setupSystemExitInterceptor(): Unit = {
     System.setSecurityManager(new SecurityManager {

--- a/src/test/scala/co/cobli/kafka/mirror/SystemExitInterceptor.scala
+++ b/src/test/scala/co/cobli/kafka/mirror/SystemExitInterceptor.scala
@@ -1,0 +1,29 @@
+
+package co.cobli.kafka.mirror
+
+import java.security.Permission
+
+
+/**
+  * Hack to intercept Java System.exit() on tests
+  */
+trait SystemExitInterceptor {
+
+  sealed case class ExitException(status: Int) extends SecurityException("System.exit() is not allowed")
+
+  def setupSystemExitInterceptor(): Unit = {
+    System.setSecurityManager(new SecurityManager {
+
+      override def checkPermission(perm: Permission): Unit = {}
+
+      override def checkPermission(perm: Permission, context: Object): Unit = {}
+
+      override def checkExit(status: Int): Unit = {
+        super.checkExit(status)
+        throw ExitException(status)
+      }
+    })
+  }
+
+  def dismissSystemExitInterceptor(): Unit = System.setSecurityManager(null)
+}

--- a/src/test/scala/co/cobli/kafka/mirror/TopicAdministration.scala
+++ b/src/test/scala/co/cobli/kafka/mirror/TopicAdministration.scala
@@ -1,0 +1,105 @@
+
+package co.cobli.kafka.mirror
+
+import java.util.Properties
+
+import scala.collection.JavaConverters._
+
+import kafka.zk.{AdminZkClient, KafkaZkClient}
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.common.config.ConfigResource
+import org.apache.kafka.common.config.ConfigResource.Type
+import org.apache.kafka.common.internals.Topic
+
+
+/**
+  * Topics manipulation for testing propose
+  */
+trait TopicAdministration {
+
+  val zkClientSrc: KafkaZkClient
+  val kafkaClientDst: AdminClient
+
+  /** AdminZkClient is flagged as "internal class"
+    * using it through this implicit for further changes
+    *
+    * @see kafka.zk.AdminZkClient
+    * @param zkClientSrc Kafka connection through zookeeper
+    */
+  implicit class AdminZkClientAdapter(zkClientSrc: KafkaZkClient) {
+
+    private val adminZkClient = new AdminZkClient(zkClientSrc)
+
+    implicit class MapToProperties(map: Map[String, String]) {
+      def toProperties: Properties = {
+        val configAsProps = new Properties()
+        map.foreach { case (key, value) => configAsProps.setProperty(key, value) }
+        configAsProps
+      }
+    }
+
+    def createTopic(name: String, numPartitions: Int, replicationFactor: Int, config: Map[String, String] = Map.empty): Unit = {
+      adminZkClient.createTopic(name, numPartitions, replicationFactor, config.toProperties)
+    }
+
+    def alterTopicConfig(name: String, config: Map[String, String]): Unit = {
+      adminZkClient.changeTopicConfig(name, config.toProperties)
+    }
+  }
+
+  def removeAllTopics(): Unit = {
+    removeAllSrcTopics()
+    removeAllDstTopics()
+  }
+
+  def removeAllSrcTopics(): Unit = {
+    zkClientSrc.getAllTopicsInCluster.foreach(topic => {
+      removeSrcTopic(topic)
+    }
+    )
+  }
+
+  def removeSrcTopic(topic: String): Unit = {
+    if (!Topic.isInternal(topic)) {
+      zkClientSrc.createDeleteTopicPath(topic)
+      while (zkClientSrc.topicExists(topic)) Thread.sleep(500)
+    }
+  }
+
+  def removeAllDstTopics(): Unit = {
+    getDstTopicList.foreach(
+      removeDstTopic
+    )
+  }
+
+  def removeDstTopic(topic: String): Unit = if (!Topic.isInternal(topic)) kafkaClientDst.deleteTopics(Set(topic).asJava).all().get()
+
+  def getDstTopicList: Set[String] = {
+    kafkaClientDst.listTopics().names().get().asScala.toSet
+  }
+
+  def addSrcTopic(name: String, numPartitions: Int, replicationFactor: Int, config: Map[String, String] = Map.empty): Unit = {
+    zkClientSrc.createTopic(name, numPartitions, replicationFactor, config)
+  }
+
+  def alterSrcTopicConfig(name: String, config: Map[String, String]): Unit = {
+    zkClientSrc.alterTopicConfig(name, config)
+  }
+
+  def getDstTopic(name: String): Option[(Int, Int, Map[String, String])] = {
+    val topicParam = Set(name).asJavaCollection
+    val topicDescriptionOpt = kafkaClientDst.describeTopics(topicParam).all().get().asScala.get(name)
+    topicDescriptionOpt match {
+      case Some(topicDescription) =>
+        val topicParam = Set(new ConfigResource(Type.TOPIC, topicDescription.name())).asJavaCollection
+        val topicConfig = kafkaClientDst.describeConfigs(topicParam).all().get()
+        val config = for {
+          configs <- topicConfig.asScala.values
+          entry <- configs.entries().asScala
+        } yield entry.name() -> entry.value()
+
+        Some(topicDescription.partitions().size(), topicDescription.partitions().iterator().next().replicas().size, config.toMap)
+      case None => None
+    }
+  }
+}

--- a/src/test/scala/co/cobli/kafka/mirror/TopicsMirrorCommandSpec.scala
+++ b/src/test/scala/co/cobli/kafka/mirror/TopicsMirrorCommandSpec.scala
@@ -1,0 +1,231 @@
+
+package co.cobli.kafka.mirror
+
+import java.io.ByteArrayOutputStream
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.util.Random
+
+import kafka.zk.KafkaZkClient
+import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig}
+import org.apache.kafka.common.utils.Time
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FeatureSpec, GivenWhenThen}
+
+
+class TopicsMirrorCommandSpec extends FeatureSpec with GivenWhenThen with TopicAdministration with SystemExitInterceptor with BeforeAndAfter
+  with BeforeAndAfterAll {
+
+  val sourceConnString = "localhost:2181"
+  val bootstrapServersDst = "localhost:9092"
+  val commandConfigPropertyDst: Map[String, String] = Map(
+    "sasl.mechanism" -> "PLAIN",
+    "security.protocol" -> "SASL_PLAINTEXT",
+    "sasl.jaas.config" -> "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"admin\" password=\"admin-secret\";"
+  )
+
+  val zkClientSrc = KafkaZkClient(
+    connectString = sourceConnString,
+    isSecure = false,
+    sessionTimeoutMs = 10000,
+    connectionTimeoutMs = 10000,
+    maxInFlightRequests = 10000,
+    Time.SYSTEM
+  )
+
+  val configDst: Map[String, String] = commandConfigPropertyDst + (AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrapServersDst)
+
+  val kafkaClientDst: AdminClient = AdminClient.create(
+    configDst.asInstanceOf[Map[String, AnyRef]].asJava
+  )
+
+  before {
+    removeAllTopics()
+  }
+
+  override protected def beforeAll(): Unit = setupSystemExitInterceptor()
+
+  override protected def afterAll(): Unit = dismissSystemExitInterceptor()
+
+  info("As a Kafka administrator")
+  info("I want to be able to mirror kafka topics from a kafka to another")
+
+  feature("Mirror kafka topics") {
+    scenario("Both kafkas are empty") {
+      Given("that kafka source has no topic")
+
+      When("topic mirror is run")
+      val (status, _, _) = executeKafkaMirroring()
+
+      Then("should return successful result")
+      assert(status == 0)
+
+      And("not create anything on destination")
+      assert(getDstTopicList.isEmpty)
+    }
+
+    scenario("Source kafka has one topic") {
+      Given("that kafka source has one topic")
+      val (name, numPartitions, replicationFactor, _) = generateRandomTopic()
+
+      When("topic mirror is run")
+      val (status, _, _) = executeKafkaMirroring()
+
+      Then("should return successful result")
+      assert(status == 0)
+
+      And("create a single topic on destination")
+      assertResult(Set(name)) {
+        getDstTopicList
+      }
+
+      assertDestinationTopicAttributes(name, numPartitions, replicationFactor, Map.empty)
+    }
+
+    scenario("Source kafka has one topic with config entries") {
+      Given("that kafka source has one topic with config entries")
+      val (name, numPartitions, replicationFactor, config) = generateRandomTopic(generateRandomConfig())
+
+      When("topic mirror is run")
+      val (status, _, _) = executeKafkaMirroring()
+
+      Then("should return successful result")
+      assert(status == 0)
+
+      And("create a single topic on destination")
+      assertResult(Set(name)) {
+        getDstTopicList
+      }
+
+      assertDestinationTopicAttributes(name, numPartitions, replicationFactor, config)
+    }
+
+    scenario("Source kafka has 2 or more topic with and without config entries") {
+      Given("that kafka source has 2 or more topic with and without config entries")
+      val topics: mutable.Set[(String, Int, Int, Map[String, String])] = mutable.Set.empty
+
+      (0 to 1 + Random.nextInt(3)).foreach(_ => {
+        topics += generateRandomTopic()
+      })
+      (0 to 1 + Random.nextInt(3)).foreach(_ => {
+        topics += generateRandomTopic(generateRandomConfig())
+      })
+
+      When("topic mirror is run")
+      val (status, _, _) = executeKafkaMirroring()
+
+      Then("should return successful result")
+      assert(status == 0)
+
+      And("create all topics on destination")
+      assert(topics.map(_._1) == getDstTopicList)
+
+      And("with all equivalent attributes")
+      topics.foreach {
+        case (name, numPartitions, replicationFactor, config) => assertDestinationTopicAttributes(name, numPartitions, replicationFactor, config)
+      }
+    }
+
+    scenario("Mirror configuration parameters of topics") {
+      Given("that kafka source and destiny has 2 mirrored topic ")
+      val (name1, numPartitions1, replicationFactor1, _) = generateRandomTopic()
+      val (name2, numPartitions2, replicationFactor2, _) = generateRandomTopic(generateRandomConfig())
+      executeKafkaMirroring()
+
+      When("source kafka topics change its configuration")
+      val config1 = generateRandomConfig()
+      val config2 = generateRandomConfig()
+      alterSrcTopicConfig(name1, config1)
+      alterSrcTopicConfig(name2, config2)
+
+      When("topic mirror is run")
+      val (status, _, _) = executeKafkaMirroring()
+
+      Then("should return successful result")
+      assert(status == 0)
+
+      And("change topics configuration on destination")
+
+      assertDestinationTopicAttributes(name1, numPartitions1, replicationFactor1, config1)
+      assertDestinationTopicAttributes(name2, numPartitions2, replicationFactor2, config2)
+    }
+
+    def generateRandomTopic(config: Map[String, String] = Map.empty): (String, Int, Int, Map[String, String]) = {
+      val numPartitions = 1 + Random.nextInt(10)
+      //val replicationFactor = 1 + Random.nextInt(3);
+      val replicationFactor = 1
+      val name = "test_topic_" + (Random.alphanumeric take 10).mkString
+      addSrcTopic(name, numPartitions, replicationFactor, config)
+      (name, numPartitions, replicationFactor, config)
+    }
+
+    def generateRandomConfig(): Map[String, String] = {
+      Map(
+        "delete.retention.ms" -> (80000000 + Random.nextInt(6400000)).toString,
+        "min.cleanable.dirty.ratio" -> (0.1 + Random.nextDouble() / 2).toString,
+        "compression.type" -> Random.shuffle(List("uncompressed", "gzip")).head
+      )
+    }
+
+    def assertDestinationTopicAttributes(name: String, numPartitions: Int, replicationFactor: Int, config: Map[String, String]) {
+
+      val topicOpt = getDstTopic(name)
+
+      And(name + " must exists")
+      assert(topicOpt.nonEmpty)
+      val topic = topicOpt.get
+
+      And(name + " must have same number of partitions")
+      assertResult(numPartitions) {
+        topic._1
+      }
+
+      And(name + " must have same replication factor")
+      assertResult(replicationFactor) {
+        topic._2
+      }
+
+      And(name + " must contains same configuration entries")
+      config.foreach {
+        case (key, expected) =>
+          assert(topic._3.get(key).isDefined)
+          val got = topic._3(key)
+          assertResult(expected, s"on topic $name in config entry $key") {
+            got
+          }
+      }
+    }
+
+    def executeKafkaMirroring(): (Int, String, String) = {
+      var status = 0
+      val stream = new ByteArrayOutputStream()
+      val streamErr = new ByteArrayOutputStream()
+      Console.withOut(stream) {
+        Console.withErr(streamErr) {
+          try {
+            TopicsMirrorCommand.main(mirrorCommand())
+          } catch {
+            case e: ExitException =>
+              status = e.status
+          }
+        }
+      }
+      info(stream.toString())
+      info(streamErr.toString())
+      (status, stream.toString(), streamErr.toString())
+    }
+
+    def mirrorCommand(): Array[String] = {
+
+      val configDst = commandConfigPropertyDst.foldLeft(Array.empty[String]) {
+        (acc: Array[String], entry) => acc ++ Array("--command-config-property-dst", s"${entry._1}=${entry._2}")
+      }
+
+      Array(
+        "--mirror",
+        "--zookeeper-src", sourceConnString,
+        "--bootstrap-servers-dst", bootstrapServersDst,
+      ) ++ configDst
+    }
+  }
+}


### PR DESCRIPTION
```
Diff or mirror topics metadata between kafkas.
Option                                   Description                            
------                                   -----------                            
--bootstrap-servers-dst <String: hosts>  REQUIRED: The connection string for    
                                           the destination kafka connection in  
                                           the form host:port.                  
--command-config-property-dst <String:   A mechanism to pass user-defined       
  dst_prop>                                properties in the form key=value to  
                                           the destination kafka Admin Client   
                                           connection. Multiple entries allowed.
--diff                                   List topics differences.               
--help                                   Print usage information.               
--mirror                                 Change or create topics on destination 
--zookeeper-src <String: hosts>          REQUIRED: The connection string for    
                                           the source zookeeper connection in   
                                           the form host:port. Multiple hosts   
                                           can be given to allow fail-over.
```